### PR TITLE
fix: use full refspec for Dokku push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,7 +176,8 @@ jobs:
       - name: Deploy to Dokku (Staging)
         run: |
           git remote add dokku dokku@${{ secrets.HETZNER_HOST }}:rental-studio-staging || true
-          if ! OUTPUT=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/dokku_deploy" git push dokku HEAD:main --force 2>&1); then
+          # Use full refspec for first push (when remote branch doesn't exist yet)
+          if ! OUTPUT=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/dokku_deploy" git push dokku HEAD:refs/heads/main --force 2>&1); then
             echo "::error::Deployment to staging failed: ${OUTPUT}"
             exit 1
           fi
@@ -265,7 +266,8 @@ jobs:
       - name: Deploy to Dokku (Production)
         run: |
           git remote add dokku dokku@${{ secrets.HETZNER_HOST }}:rental-studio || true
-          if ! OUTPUT=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/dokku_deploy" git push dokku HEAD:main --force 2>&1); then
+          # Use full refspec for first push (when remote branch doesn't exist yet)
+          if ! OUTPUT=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/dokku_deploy" git push dokku HEAD:refs/heads/main --force 2>&1); then
             echo "::error::Deployment to production failed: ${OUTPUT}"
             exit 1
           fi


### PR DESCRIPTION
Fixes first-time deployment when remote branch doesn't exist yet.

Uses `HEAD:refs/heads/main` instead of `HEAD:main` to handle the case when Dokku app has no commits yet.