### PR TITLE
feat: add subdomain tenant middleware

### DIFF
--- a/apps/web/src/components/layouts/AppLayout.tsx
+++ b/apps/web/src/components/layouts/AppLayout.tsx
@@ -25,7 +25,7 @@ export const AppLayout: FC<AppLayoutProps> = ({ children }) => {
                   <a href="/app/properties">Properties</a>
                 </li>
                 <li>
-                  <a href="/app/tenants">Tenants</a>
+                  <a href="/app/renters">Renters</a>
                 </li>
               </ul>
             </div>

--- a/apps/web/src/index.test.ts
+++ b/apps/web/src/index.test.ts
@@ -191,7 +191,7 @@ describe('Web App', () => {
 
     it('should return 404 JSON for unknown API routes', async () => {
       const res = await app.request('/api/unknown', {
-        headers: { Accept: 'application/json' },
+        headers: { Accept: 'application/json', Host: 'demo.localhost' },
       });
       const body = (await res.json()) as ErrorResponse;
 

--- a/apps/web/src/index.test.ts
+++ b/apps/web/src/index.test.ts
@@ -11,6 +11,7 @@
  * request time. The default PORT=3000 is used for test CSRF validation.
  */
 process.env.BYPASS_AUTH = 'true';
+process.env.TENANT_BASE_DOMAIN = 'localhost';
 
 import { describe, expect, it } from 'bun:test';
 import { APP_NAME } from '@rental-studio/core';
@@ -128,7 +129,9 @@ describe('Web App', () => {
 
   describe('App routes (/app/*)', () => {
     it('GET /app should return dashboard', async () => {
-      const res = await app.request('/app');
+      const res = await app.request('/app', {
+        headers: { Host: 'demo.localhost' },
+      });
 
       expect(res.status).toBe(200);
       expect(await res.text()).toContain('Dashboard');
@@ -140,7 +143,9 @@ describe('Web App', () => {
       process.env.BYPASS_AUTH = 'false';
 
       try {
-        const res = await app.request('/app');
+        const res = await app.request('/app', {
+          headers: { Host: 'demo.localhost' },
+        });
 
         expect(res.status).toBe(302);
         expect(res.headers.get('Location')).toBe('/auth/login');
@@ -153,11 +158,21 @@ describe('Web App', () => {
 
   describe('API routes (/api/*)', () => {
     it('GET /api/version should return version info', async () => {
-      const res = await app.request('/api/version');
+      const res = await app.request('/api/version', {
+        headers: { Host: 'demo.localhost' },
+      });
       const body = (await res.json()) as VersionResponse;
 
       expect(res.status).toBe(200);
       expect(body.version).toBeDefined();
+    });
+
+    it('GET /api/version should return 404 without tenant subdomain', async () => {
+      const res = await app.request('/api/version', {
+        headers: { Host: 'localhost' },
+      });
+
+      expect(res.status).toBe(404);
     });
   });
 

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -63,6 +63,7 @@ app.get('/health', (c) => {
 
 // Routes
 app.route('/', index);
+// Auth routes are global (not tenant-scoped) until we need tenant-specific auth flows.
 app.route('/auth', auth);
 app.route('/app', appRouter);
 app.route('/api', api);

--- a/apps/web/src/middleware/tenant.ts
+++ b/apps/web/src/middleware/tenant.ts
@@ -13,11 +13,14 @@ function isValidTenantSlug(slug: string): boolean {
 }
 
 function getRequestHost(c: Context): string | null {
+  // Only enable TRUST_PROXY when a trusted proxy strips incoming forwarded headers.
   const trustProxy = process.env.TRUST_PROXY === 'true';
   const forwardedHost = trustProxy ? c.req.header('x-forwarded-host') : null;
   const hostHeader = forwardedHost?.split(',')[0]?.trim() || c.req.header('host');
   if (!hostHeader) return null;
-  return hostHeader.split(':')[0]?.toLowerCase() || null;
+  const host = hostHeader.split(':')[0]?.toLowerCase() || null;
+  if (!host) return null;
+  return host.replace(/^\[(.*)\]$/, '$1');
 }
 
 function resolveTenantSlug(host: string): string | null {
@@ -33,18 +36,14 @@ function resolveTenantSlug(host: string): string | null {
     return slug || null;
   }
 
-  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
-    return null;
-  }
+  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return null;
 
   if (host.endsWith('.localhost')) {
     const slug = host.slice(0, -'.localhost'.length);
     return slug || null;
   }
 
-  const parts = host.split('.');
-  if (parts.length < 3) return null;
-  return parts[0] || null;
+  return null;
 }
 
 function logTenantIssue(c: Context, reason: string, host?: string, slug?: string): void {

--- a/apps/web/src/middleware/tenant.ts
+++ b/apps/web/src/middleware/tenant.ts
@@ -19,10 +19,25 @@ function isValidTenantSlug(slug: string): boolean {
   return TENANT_SLUG_PATTERN.test(slug);
 }
 
+function isLocalHost(host: string): boolean {
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+}
+
+function getForwardedHost(forwardedHeader: string | null): string | null {
+  if (!forwardedHeader) return null;
+  const firstEntry = forwardedHeader.split(',')[0]?.trim();
+  if (!firstEntry) return null;
+  const match = firstEntry.match(/host=([^;]+)/i);
+  if (!match) return null;
+  return match[1]?.replace(/^"|"$/g, '') ?? null;
+}
+
 function getRequestHost(c: Context): string | null {
   // Only enable TRUST_PROXY when a trusted proxy strips incoming forwarded headers.
   const trustProxy = process.env.TRUST_PROXY === 'true';
-  const forwardedHost = trustProxy ? c.req.header('x-forwarded-host') : null;
+  const forwardedHost = trustProxy
+    ? (c.req.header('x-forwarded-host') ?? getForwardedHost(c.req.header('forwarded')))
+    : null;
   if (trustProxy && !forwardedHost) return null;
   const hostHeader = forwardedHost?.split(',')[0]?.trim() || c.req.header('host');
   if (!hostHeader) return null;
@@ -46,7 +61,7 @@ function resolveTenantSlug(host: string): string | null {
     return slug || null;
   }
 
-  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return null;
+  if (isLocalHost(host)) return null;
 
   if (host.endsWith('.localhost')) {
     const slug = host.slice(0, -'.localhost'.length);
@@ -87,20 +102,18 @@ export function requireTenant(c: Context): TenantContext {
 export const withTenant = async (c: Context, next: Next) => {
   const host = getRequestHost(c);
   if (!host) {
-    logTenantIssue(c, 'missing_host');
+    logTenantIssue(
+      c,
+      process.env.TRUST_PROXY === 'true' ? 'missing_forwarded_host' : 'missing_host',
+    );
     throw new HTTPException(404, { message: 'Not Found' });
   }
 
-  let slug: string | null;
-  try {
-    slug = resolveTenantSlug(host);
-  } catch (error) {
-    if (error instanceof HTTPException) {
-      logTenantIssue(c, 'base_domain_missing', host);
-      throw error;
-    }
-    throw error;
+  if (!baseDomain && !isLocalHost(host) && !host.endsWith('.localhost')) {
+    logTenantIssue(c, 'base_domain_unset', host);
   }
+
+  const slug = resolveTenantSlug(host);
   if (!slug) {
     logTenantIssue(c, 'missing_subdomain', host);
     throw new HTTPException(404, { message: 'Not Found' });

--- a/apps/web/src/middleware/tenant.ts
+++ b/apps/web/src/middleware/tenant.ts
@@ -1,6 +1,13 @@
 import type { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
+const isProduction = process.env.NODE_ENV === 'production';
+const baseDomain = process.env.TENANT_BASE_DOMAIN?.toLowerCase();
+
+if (isProduction && !baseDomain) {
+  throw new Error('TENANT_BASE_DOMAIN must be configured in production');
+}
+
 export type TenantContext = {
   slug: string;
   host: string;
@@ -16,6 +23,7 @@ function getRequestHost(c: Context): string | null {
   // Only enable TRUST_PROXY when a trusted proxy strips incoming forwarded headers.
   const trustProxy = process.env.TRUST_PROXY === 'true';
   const forwardedHost = trustProxy ? c.req.header('x-forwarded-host') : null;
+  if (trustProxy && !forwardedHost) return null;
   const hostHeader = forwardedHost?.split(',')[0]?.trim() || c.req.header('host');
   if (!hostHeader) return null;
   const normalized = hostHeader.toLowerCase();
@@ -31,11 +39,6 @@ function getRequestHost(c: Context): string | null {
 }
 
 function resolveTenantSlug(host: string): string | null {
-  const baseDomain = process.env.TENANT_BASE_DOMAIN?.toLowerCase();
-  if (!baseDomain && process.env.NODE_ENV === 'production') {
-    throw new HTTPException(500, { message: 'Tenant base domain not configured' });
-  }
-
   if (baseDomain) {
     if (host === baseDomain) return null;
     if (!host.endsWith(`.${baseDomain}`)) return null;
@@ -54,11 +57,12 @@ function resolveTenantSlug(host: string): string | null {
 }
 
 function logTenantIssue(c: Context, reason: string, host?: string, slug?: string): void {
+  const requestId = c.get('requestId') ?? 'unknown';
   console.info(
     JSON.stringify({
       level: 'info',
       event: 'tenant_resolution_failed',
-      requestId: c.get('requestId'),
+      requestId,
       method: c.req.method,
       path: c.req.path,
       reason,

--- a/apps/web/src/middleware/tenant.ts
+++ b/apps/web/src/middleware/tenant.ts
@@ -18,9 +18,16 @@ function getRequestHost(c: Context): string | null {
   const forwardedHost = trustProxy ? c.req.header('x-forwarded-host') : null;
   const hostHeader = forwardedHost?.split(',')[0]?.trim() || c.req.header('host');
   if (!hostHeader) return null;
-  const host = hostHeader.split(':')[0]?.toLowerCase() || null;
-  if (!host) return null;
-  return host.replace(/^\[(.*)\]$/, '$1');
+  const normalized = hostHeader.toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.startsWith('[')) {
+    const endIndex = normalized.indexOf(']');
+    if (endIndex === -1) return null;
+    return normalized.slice(1, endIndex);
+  }
+
+  return normalized.split(':')[0] || null;
 }
 
 function resolveTenantSlug(host: string): string | null {

--- a/apps/web/src/middleware/tenant.ts
+++ b/apps/web/src/middleware/tenant.ts
@@ -13,7 +13,8 @@ function isValidTenantSlug(slug: string): boolean {
 }
 
 function getRequestHost(c: Context): string | null {
-  const forwardedHost = c.req.header('x-forwarded-host');
+  const trustProxy = process.env.TRUST_PROXY === 'true';
+  const forwardedHost = trustProxy ? c.req.header('x-forwarded-host') : null;
   const hostHeader = forwardedHost?.split(',')[0]?.trim() || c.req.header('host');
   if (!hostHeader) return null;
   return hostHeader.split(':')[0]?.toLowerCase() || null;
@@ -21,6 +22,9 @@ function getRequestHost(c: Context): string | null {
 
 function resolveTenantSlug(host: string): string | null {
   const baseDomain = process.env.TENANT_BASE_DOMAIN?.toLowerCase();
+  if (!baseDomain && process.env.NODE_ENV === 'production') {
+    throw new HTTPException(500, { message: 'Tenant base domain not configured' });
+  }
 
   if (baseDomain) {
     if (host === baseDomain) return null;
@@ -43,7 +47,7 @@ function resolveTenantSlug(host: string): string | null {
   return parts[0] || null;
 }
 
-function logTenantIssue(c: Context, reason: string): void {
+function logTenantIssue(c: Context, reason: string, host?: string, slug?: string): void {
   console.info(
     JSON.stringify({
       level: 'info',
@@ -52,6 +56,8 @@ function logTenantIssue(c: Context, reason: string): void {
       method: c.req.method,
       path: c.req.path,
       reason,
+      host,
+      slug,
     }),
   );
 }
@@ -75,14 +81,23 @@ export const withTenant = async (c: Context, next: Next) => {
     throw new HTTPException(404, { message: 'Not Found' });
   }
 
-  const slug = resolveTenantSlug(host);
+  let slug: string | null;
+  try {
+    slug = resolveTenantSlug(host);
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      logTenantIssue(c, 'base_domain_missing', host);
+      throw error;
+    }
+    throw error;
+  }
   if (!slug) {
-    logTenantIssue(c, 'missing_subdomain');
+    logTenantIssue(c, 'missing_subdomain', host);
     throw new HTTPException(404, { message: 'Not Found' });
   }
 
   if (!isValidTenantSlug(slug)) {
-    logTenantIssue(c, 'invalid_subdomain');
+    logTenantIssue(c, 'invalid_subdomain', host, slug);
     throw new HTTPException(404, { message: 'Not Found' });
   }
 

--- a/apps/web/src/middleware/tenant.ts
+++ b/apps/web/src/middleware/tenant.ts
@@ -1,0 +1,91 @@
+import type { Context, Next } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+export type TenantContext = {
+  slug: string;
+  host: string;
+};
+
+const TENANT_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+function isValidTenantSlug(slug: string): boolean {
+  return TENANT_SLUG_PATTERN.test(slug);
+}
+
+function getRequestHost(c: Context): string | null {
+  const forwardedHost = c.req.header('x-forwarded-host');
+  const hostHeader = forwardedHost?.split(',')[0]?.trim() || c.req.header('host');
+  if (!hostHeader) return null;
+  return hostHeader.split(':')[0]?.toLowerCase() || null;
+}
+
+function resolveTenantSlug(host: string): string | null {
+  const baseDomain = process.env.TENANT_BASE_DOMAIN?.toLowerCase();
+
+  if (baseDomain) {
+    if (host === baseDomain) return null;
+    if (!host.endsWith(`.${baseDomain}`)) return null;
+    const slug = host.slice(0, -baseDomain.length - 1);
+    return slug || null;
+  }
+
+  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
+    return null;
+  }
+
+  if (host.endsWith('.localhost')) {
+    const slug = host.slice(0, -'.localhost'.length);
+    return slug || null;
+  }
+
+  const parts = host.split('.');
+  if (parts.length < 3) return null;
+  return parts[0] || null;
+}
+
+function logTenantIssue(c: Context, reason: string): void {
+  console.info(
+    JSON.stringify({
+      level: 'info',
+      event: 'tenant_resolution_failed',
+      requestId: c.get('requestId'),
+      method: c.req.method,
+      path: c.req.path,
+      reason,
+    }),
+  );
+}
+
+export function getTenant(c: Context): TenantContext | null {
+  return c.get('tenant') ?? null;
+}
+
+export function requireTenant(c: Context): TenantContext {
+  const tenant = getTenant(c);
+  if (!tenant) {
+    throw new HTTPException(404, { message: 'Not Found' });
+  }
+  return tenant;
+}
+
+export const withTenant = async (c: Context, next: Next) => {
+  const host = getRequestHost(c);
+  if (!host) {
+    logTenantIssue(c, 'missing_host');
+    throw new HTTPException(404, { message: 'Not Found' });
+  }
+
+  const slug = resolveTenantSlug(host);
+  if (!slug) {
+    logTenantIssue(c, 'missing_subdomain');
+    throw new HTTPException(404, { message: 'Not Found' });
+  }
+
+  if (!isValidTenantSlug(slug)) {
+    logTenantIssue(c, 'invalid_subdomain');
+    throw new HTTPException(404, { message: 'Not Found' });
+  }
+
+  c.set('tenant', { slug, host });
+  await next();
+};

--- a/apps/web/src/routes/api.ts
+++ b/apps/web/src/routes/api.ts
@@ -1,8 +1,10 @@
 import { APP_VERSION } from '@rental-studio/core';
 import { Hono } from 'hono';
+import { withTenant } from '../middleware/tenant';
 
 const api = new Hono();
 
+api.use(withTenant);
 api.get('/version', (c) => c.json({ version: APP_VERSION }));
 
 export default api;

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -69,6 +69,8 @@ appRouter.get('/renters', (c) => {
   );
 });
 
+appRouter.get('/tenants', (c) => c.redirect('/app/renters', 301));
+
 appRouter.get('/payments', (c) => {
   return c.render(
     <>

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -2,34 +2,39 @@ import { Hono } from 'hono';
 import { Card } from '../components';
 import { requireAuth } from '../middleware/auth';
 import { appRenderer } from '../middleware/renderer';
+import { withTenant } from '../middleware/tenant';
 
 const appRouter = new Hono();
 
 /**
  * Middleware order:
  * 1. CSRF protection (applied at app level in index.ts, runs first)
- * 2. Authentication check (redirects to login if not authenticated)
- * 3. Renderer (wraps response in AppLayout)
+ * 2. Tenant resolution (404s when subdomain is missing/invalid)
+ * 3. Authentication check (redirects to login if not authenticated)
+ * 4. Renderer (wraps response in AppLayout)
  *
  * Note: CSRF runs before auth, so unauthenticated POST requests to /app/*
  * will receive a 403 CSRF error instead of a redirect to login. This is
  * intentional - it prevents CSRF probing attacks against protected routes.
  */
+appRouter.use(withTenant);
 appRouter.use(requireAuth);
 appRouter.use(appRenderer);
 
 appRouter.get('/', (c) => {
+  const tenant = c.get('tenant');
   return c.render(
     <>
       <h1>Dashboard</h1>
+      {tenant ? <p class="text-muted">Workspace: {tenant.slug}</p> : null}
       <div class="app-grid">
         <Card header={<strong>Properties</strong>}>
           <p>Manage your rental properties</p>
           <a href="/app/properties">View Properties →</a>
         </Card>
-        <Card header={<strong>Tenants</strong>}>
-          <p>Manage your tenants</p>
-          <a href="/app/tenants">View Tenants →</a>
+        <Card header={<strong>Renters</strong>}>
+          <p>Manage your renters</p>
+          <a href="/app/renters">View Renters →</a>
         </Card>
         <Card header={<strong>Payments</strong>}>
           <p>Track rent payments</p>
@@ -53,14 +58,14 @@ appRouter.get('/properties', (c) => {
   );
 });
 
-appRouter.get('/tenants', (c) => {
+appRouter.get('/renters', (c) => {
   return c.render(
     <>
-      <h1>Tenants</h1>
-      <p>Tenant management coming soon.</p>
+      <h1>Renters</h1>
+      <p>Renter management coming soon.</p>
       <a href="/app">← Back to Dashboard</a>
     </>,
-    { title: 'Tenants' },
+    { title: 'Renters' },
   );
 });
 

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { Card } from '../components';
 import { requireAuth } from '../middleware/auth';
 import { appRenderer } from '../middleware/renderer';
-import { withTenant } from '../middleware/tenant';
+import { requireTenant, withTenant } from '../middleware/tenant';
 
 const appRouter = new Hono();
 
@@ -22,11 +22,11 @@ appRouter.use(requireAuth);
 appRouter.use(appRenderer);
 
 appRouter.get('/', (c) => {
-  const tenant = c.get('tenant');
+  const tenant = requireTenant(c);
   return c.render(
     <>
       <h1>Dashboard</h1>
-      {tenant ? <p class="text-muted">Workspace: {tenant.slug}</p> : null}
+      <p class="text-muted">Workspace: {tenant.slug}</p>
       <div class="app-grid">
         <Card header={<strong>Properties</strong>}>
           <p>Manage your rental properties</p>

--- a/apps/web/src/types/hono.d.ts
+++ b/apps/web/src/types/hono.d.ts
@@ -1,6 +1,11 @@
 import 'hono';
 
 declare module 'hono' {
+  interface ContextVariableMap {
+    requestId: string;
+    tenant?: { slug: string; host: string };
+  }
+
   interface ContextRenderer {
     // biome-ignore lint/style/useShorthandFunctionType: Module augmentation requires interface syntax for declaration merging
     (content: string | Promise<string>, props?: { title?: string }): Response | Promise<Response>;


### PR DESCRIPTION
## Summary
- add subdomain-based tenant resolution middleware with 404s to avoid tenant enumeration
- wire tenant middleware into app and api routes and expose tenant context typing
- rename UI tenant label to renters and update tests for subdomain hosts

## Testing
- not run (not requested)